### PR TITLE
add coverage.out to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 tests/
 .vscode/
+coverage.out


### PR DESCRIPTION
This PR adds the file `coverage.out` to `.gitignore` since we don't need this file in the project I think that doesn't make sense keep track of that. 